### PR TITLE
fix: add build_from config and default BUILD_FROM arg to fix Docker b…

### DIFF
--- a/cups/Dockerfile
+++ b/cups/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM
+ARG BUILD_FROM=ghcr.io/home-assistant/aarch64-base:latest
 FROM $BUILD_FROM
 
 # Add env

--- a/cups/config.yaml
+++ b/cups/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.0.0
+version: 1.1.0
 slug: cups
 name: CUPS Print Server
 description: CUPS print server for network printing
@@ -11,6 +11,12 @@ arch:
   - aarch64
   - amd64
   - i386
+build_from:
+  armhf: ghcr.io/home-assistant/armhf-base:latest
+  armv7: ghcr.io/home-assistant/armv7-base:latest
+  aarch64: ghcr.io/home-assistant/aarch64-base:latest
+  amd64: ghcr.io/home-assistant/amd64-base:latest
+  i386: ghcr.io/home-assistant/i386-base:latest
 hassio_api: true
 host_network: true
 map:


### PR DESCRIPTION
…uild

The Dockerfile declared ARG BUILD_FROM with no default value, and config.yaml was missing the build_from mapping. Without this, the Home Assistant Supervisor couldn't inject the base image, causing
 to be empty and the build to fail with:

  InvalidDefaultArgInFrom: Default value for ARG  results
  in empty or invalid base image name

Fixes #11
Fixes #12 