### PR TITLE
Fix USB printer support by requesting USB access from HA supervisor (is…

### DIFF
--- a/cups/config.yaml
+++ b/cups/config.yaml
@@ -10,6 +10,7 @@ arch:
   - amd64
 hassio_api: true
 host_network: true
+usb: true
 map:
   - data:rw
   - share:rw


### PR DESCRIPTION
## Summary

Fix USB printer support by requesting USB access from HA supervisor (issue #23)

## Run

- **Warren run:** `run_fajq4n1036nw`
- **Agent:** pr-fixer
- **Cost:** $0.019 (50.0k in / 22.9k out / 2.1M cache-r)

## Commits (1)

- c8bd01a Fix USB printer support by requesting USB access from HA supervisor (issue #23)

## Files changed

```
cups/config.yaml | 1 +
 1 file changed, 1 insertion(+)
```

## Prompt

<details><summary>Show prompt</summary>

```
Fix 1 github issue
```

</details>

---

🤖 Opened by warren run `run_fajq4n1036nw`