### PR TITLE
Install gutenprint-cups so Canon and other PPDs appear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.3.1] — 2026-09-09
+
+- Fix missing Canon/HP/Brother CUPS PPDs: Alpine splits Gutenprint, so install
+  `gutenprint-cups` (filters + PPDs) in addition to `gutenprint`
+
 ## [1.2.1] — 2026-05-17
 
 - Fix: remove hardcoded aarch64 default from BUILD_FROM ARG

--- a/README.md
+++ b/README.md
@@ -107,8 +107,17 @@ This app supports various printer types:
 
 
 ### Printer Drivers
-   https://www.openprinting.org/download/PPD/
-   https://www.openprinting.org/drivers/
+
+Gutenprint CUPS drivers (Canon, HP, Brother, and many others) are bundled via
+the Alpine `gutenprint-cups` package. In the add-printer list, models often
+appear as a series name (for example Canon PIXMA MG5250 is **Canon MG5200
+series - CUPS+Gutenprint**).
+
+For printers Gutenprint does not cover, supply a `.deb` through
+`printer_driver_deb` (place the file in `/share`) or use a PPD from:
+
+- https://www.openprinting.org/download/PPD/
+- https://www.openprinting.org/drivers/
 
 ### Authentication Issues
 

--- a/cups/Dockerfile
+++ b/cups/Dockerfile
@@ -13,6 +13,8 @@ ENV CUPS_SERVERROOT=/share/cups/config
 # Note: hplip, foomatic-db, and foomatic-db-ppds were removed from Alpine 3.23
 # and are no longer available in stable repositories.
 # Gutenprint covers most printer models as a replacement.
+# Alpine splits this: `gutenprint` is libraries/tools only; `gutenprint-cups`
+# ships rastertogutenprint and the CUPS PPDs (Canon, HP, Brother, etc.).
 RUN \
     echo "http://dl-cdn.alpinelinux.org/alpine/v$(cat /etc/alpine-release | cut -d'.' -f1,2)/main" > /etc/apk/repositories && \
     echo "http://dl-cdn.alpinelinux.org/alpine/v$(cat /etc/alpine-release | cut -d'.' -f1,2)/community" >> /etc/apk/repositories && \
@@ -25,6 +27,7 @@ RUN \
         net-snmp \
         epson-inkjet-printer-escpr \
         gutenprint \
+        gutenprint-cups \
         gcompat \
         libstdc++ \
         dpkg \

--- a/cups/config.yaml
+++ b/cups/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.3.0
+version: 1.3.1
 slug: cups
 name: CUPS Print Server
 description: CUPS print server for network printing


### PR DESCRIPTION
## Summary
- Alpine splits Gutenprint: `gutenprint` is libraries/tools only. The add-on already claimed Gutenprint replaced foomatic/hplip, but without `gutenprint-cups` CUPS never gets `rastertogutenprint` or the model PPDs.
- Installing `gutenprint-cups` makes Canon, HP, Brother, and other Gutenprint models show up in the add-printer list (e.g. PIXMA MG5250 as **Canon MG5200 series**).
- Bump add-on version to 1.3.1.

## Test plan
- [ ] Rebuild/update the add-on on Home Assistant OS (aarch64 and/or amd64)
- [ ] Confirm start logs include `gutenprint-cups` with no apk errors
- [ ] In CUPS at `:631`, add a printer and confirm Gutenprint models appear (search for Canon MG5200 series)
- [ ] Confirm existing Epson ESC/P-R, Dymo, and Kyocera drivers still appear
- [ ] Note: `gutenprint-cups` adds ~53MB compressed / ~74MB installed to the image