### PR TITLE
AirPrint, cancel-job auth, and IPv6 web UI (1.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   `gutenprint-cups` (filters + PPDs) in addition to `gutenprint`
 - Fix web UI "Cancel Job" returning Unauthorized: put Cancel-Job in a real
   Policy with AuthType None (top-level Limit is ignored; no admin user exists)
+- Advertise shared printers via AirPrint/Bonjour: run Avahi (reflector mode)
+  and enable CUPS DNS-SD browsing so Apple devices can discover the queues
 
 ## [1.2.1] — 2026-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,18 @@
 # Changelog
 
-## [1.3.1] — 2026-09-09
+## [1.3.2] — 2026-09-09
 
-- Fix missing Canon/HP/Brother CUPS PPDs: Alpine splits Gutenprint, so install
-  `gutenprint-cups` (filters + PPDs) in addition to `gutenprint`
 - Fix web UI "Cancel Job" returning Unauthorized: put Cancel-Job in a real
   Policy with AuthType None (top-level Limit is ignored; no admin user exists)
 - Advertise shared printers via AirPrint/Bonjour: run Avahi (reflector mode)
   and enable CUPS DNS-SD browsing so Apple devices can discover the queues
 - Allow IPv6 LAN clients (@LOCAL, fe80::/10, fd00::/8). Port 631 listens on
   v6 and macOS prefers AAAA for *.local, which otherwise 403s the web UI
+
+## [1.3.1] — 2026-09-09
+
+- Fix missing Canon/HP/Brother CUPS PPDs: Alpine splits Gutenprint, so install
+  `gutenprint-cups` (filters + PPDs) in addition to `gutenprint`
 
 ## [1.2.1] — 2026-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   Policy with AuthType None (top-level Limit is ignored; no admin user exists)
 - Advertise shared printers via AirPrint/Bonjour: run Avahi (reflector mode)
   and enable CUPS DNS-SD browsing so Apple devices can discover the queues
+- Allow IPv6 LAN clients (@LOCAL, fe80::/10, fd00::/8). Port 631 listens on
+  v6 and macOS prefers AAAA for *.local, which otherwise 403s the web UI
 
 ## [1.2.1] — 2026-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fix missing Canon/HP/Brother CUPS PPDs: Alpine splits Gutenprint, so install
   `gutenprint-cups` (filters + PPDs) in addition to `gutenprint`
+- Fix web UI "Cancel Job" returning Unauthorized: put Cancel-Job in a real
+  Policy with AuthType None (top-level Limit is ignored; no admin user exists)
 
 ## [1.2.1] — 2026-05-17
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,20 @@ Visit `http://<your-ha-ip>:631` in your browser.
 
 ### Print from Devices
 
-Configure your computers or devices to use the printer at `<your-ha-ip>:631`.
+Shared printers are advertised on the LAN via AirPrint/Bonjour (Avahi). On
+iPhone, iPad, and Mac they should appear as nearby printers. Do not pick the
+printer's own LPD advertisement (for example "Canon MG5200 series") — that
+bypasses this server.
+
+To add the CUPS queue manually on macOS:
+
+1. System Settings → Printers & Scanners → Add Printer → **IP**
+2. Address: `<your-ha-hostname>` (e.g. `homeassistant.local`)
+3. Protocol: **IPP**
+4. Queue: `printers/<queue-name>`
+5. Use: **Auto Select**
+
+You can also print to `ipp://<your-ha-ip>:631/printers/<queue-name>`.
 
 ## Supported Printer Types
 

--- a/cups/Dockerfile
+++ b/cups/Dockerfile
@@ -28,6 +28,8 @@ RUN \
         epson-inkjet-printer-escpr \
         gutenprint \
         gutenprint-cups \
+        avahi \
+        dbus \
         gcompat \
         libstdc++ \
         dpkg \

--- a/cups/config.yaml
+++ b/cups/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 1.3.1
+version: 1.3.2
 slug: cups
 name: CUPS Print Server
 description: CUPS print server for network printing

--- a/cups/config.yaml
+++ b/cups/config.yaml
@@ -17,8 +17,10 @@ map:
 init: false
 ports:
   631/tcp: 631
+  631/udp: 631
 ports_description:
   631/tcp: CUPS web interface and printing port
+  631/udp: IPP browsing / AirPrint
 options:
   admin_username: "admin"
   admin_password: "admin"

--- a/cups/rootfs/etc/avahi/avahi-daemon.conf
+++ b/cups/rootfs/etc/avahi/avahi-daemon.conf
@@ -1,0 +1,19 @@
+# Publish CUPS/AirPrint on the LAN. Reflector + reuse allows this daemon to
+# coexist with Home Assistant OS mDNS (systemd-resolved / host Avahi).
+[server]
+use-ipv4=yes
+use-ipv6=yes
+enable-dbus=yes
+disallow-other-stacks=no
+ratelimit-interval-usec=1000000
+ratelimit-burst=1000
+
+[wide-area]
+enable-wide-area=yes
+
+[publish]
+publish-hinfo=no
+publish-workstation=no
+
+[reflector]
+enable-reflector=yes

--- a/cups/rootfs/etc/cont-init.d/cups.sh
+++ b/cups/rootfs/etc/cont-init.d/cups.sh
@@ -21,6 +21,12 @@ cat > /share/cups/config/cupsd.conf << 'EOL'
 # Listen on all interfaces
 Listen 0.0.0.0:631
 
+WebInterface Yes
+DefaultAuthType None
+DefaultEncryption Never
+JobSheets none,none
+PreserveJobHistory No
+
 # Allow access from local network
 <Location />
   Order allow,deny
@@ -30,7 +36,6 @@ Listen 0.0.0.0:631
   Allow 192.168.0.0/16
 </Location>
 
-# Admin access (no authentication)
 <Location /admin>
   Order allow,deny
   Allow localhost
@@ -39,7 +44,14 @@ Listen 0.0.0.0:631
   Allow 192.168.0.0/16
 </Location>
 
-# Job management permissions
+<Location /admin/conf>
+  Order allow,deny
+  Allow localhost
+  Allow 10.0.0.0/8
+  Allow 172.16.0.0/12
+  Allow 192.168.0.0/16
+</Location>
+
 <Location /jobs>
   Order allow,deny
   Allow localhost
@@ -48,21 +60,42 @@ Listen 0.0.0.0:631
   Allow 192.168.0.0/16
 </Location>
 
-<Limit Send-Document Send-URI Hold-Job Release-Job Restart-Job Purge-Jobs Set-Job-Attributes Create-Job-Subscription Renew-Subscription Cancel-Subscription Get-Notifications Reprocess-Job Cancel-Current-Job Suspend-Current-Job Resume-Job Cancel-My-Jobs Close-Job CUPS-Move-Job CUPS-Get-Document>
-  Order allow,deny
-  Allow localhost
-  Allow 10.0.0.0/8
-  Allow 172.16.0.0/12
-  Allow 192.168.0.0/16
-</Limit>
+# Top-level <Limit> is ignored by cupsd; job ops must live in a Policy.
+# Cancel-Job (the web UI "Cancel Job" button) is not Cancel-My-Jobs.
+# The baked-in default policy requires @OWNER/@SYSTEM, but this image
+# never creates an admin user, so cancels always returned Unauthorized.
+<Policy default>
+  JobPrivateAccess all
+  JobPrivateValues none
+  SubscriptionPrivateAccess all
+  SubscriptionPrivateValues none
 
-# Enable web interface
-WebInterface Yes
+  <Limit Create-Job Print-Job Print-URI Validate-Job>
+    Order allow,deny
+    Allow localhost
+    Allow 10.0.0.0/8
+    Allow 172.16.0.0/12
+    Allow 192.168.0.0/16
+  </Limit>
 
-# Default settings
-DefaultAuthType None
-JobSheets none,none
-PreserveJobHistory No
+  <Limit Send-Document Send-URI Hold-Job Release-Job Restart-Job Purge-Jobs Set-Job-Attributes Create-Job-Subscription Renew-Subscription Cancel-Subscription Get-Notifications Reprocess-Job Cancel-Job Cancel-Jobs Cancel-Current-Job Cancel-My-Jobs Suspend-Current-Job Resume-Job Close-Job CUPS-Move-Job CUPS-Get-Document Pause-Printer Resume-Printer Enable-Printer Disable-Printer Pause-Printer-After-Current-Job Hold-New-Jobs Release-Held-New-Jobs CUPS-Accept-Jobs CUPS-Reject-Jobs Promote-Job CUPS-Add-Modify-Printer CUPS-Delete-Printer CUPS-Add-Modify-Class CUPS-Delete-Class CUPS-Set-Default CUPS-Get-Devices>
+    AuthType None
+    Order allow,deny
+    Allow localhost
+    Allow 10.0.0.0/8
+    Allow 172.16.0.0/12
+    Allow 192.168.0.0/16
+  </Limit>
+
+  <Limit All>
+    AuthType None
+    Order allow,deny
+    Allow localhost
+    Allow 10.0.0.0/8
+    Allow 172.16.0.0/12
+    Allow 192.168.0.0/16
+  </Limit>
+</Policy>
 EOL
 
 # Migrate legacy data from /data/cups to /share/cups if present

--- a/cups/rootfs/etc/cont-init.d/cups.sh
+++ b/cups/rootfs/etc/cont-init.d/cups.sh
@@ -18,12 +18,16 @@ chmod -R 775 /share/cups
 # Write a fresh cupsd.conf (this is static config we own)
 # ─────────────────────────────────────────────────────────────
 cat > /share/cups/config/cupsd.conf << 'EOL'
-# Listen on all interfaces
-Listen 0.0.0.0:631
+# Listen on all interfaces (Port covers TCP+UDP for IPP/AirPrint)
+Port 631
+Listen /run/cups/cups.sock
 
 WebInterface Yes
 DefaultAuthType None
 DefaultEncryption Never
+Browsing Yes
+BrowseLocalProtocols dnssd
+DefaultShared Yes
 JobSheets none,none
 PreserveJobHistory No
 
@@ -203,6 +207,31 @@ fi
 # Verify printer drivers are available
 echo "Available printer drivers:"
 lpinfo -m 2>/dev/null | head -20 || echo "CUPS not yet running; drivers will be listed after start."
+
+# D-Bus + Avahi so cupsd can advertise shared queues as AirPrint (_ipp._tcp).
+# This init script blocks on cupsd -f, so daemons must start here rather than
+# as sibling s6 services.
+echo "Starting D-Bus and Avahi for AirPrint..."
+mkdir -p /run/dbus /run/avahi-daemon
+dbus-uuidgen --ensure >/dev/null 2>&1 || true
+if [ ! -S /run/dbus/system_bus_socket ]; then
+    dbus-daemon --system || echo "Warning: dbus-daemon failed to start"
+fi
+for _ in $(seq 1 25); do
+    [ -S /run/dbus/system_bus_socket ] && break
+    sleep 0.2
+done
+if [ ! -S /run/avahi-daemon/socket ]; then
+    if avahi-daemon --daemonize --no-drop-root --no-rlimits; then
+        echo "Avahi started."
+    else
+        echo "Warning: avahi-daemon failed; AirPrint discovery may not work."
+    fi
+fi
+for _ in $(seq 1 25); do
+    [ -S /run/avahi-daemon/socket ] && break
+    sleep 0.2
+done
 
 # Start CUPS service
 /usr/sbin/cupsd -f

--- a/cups/rootfs/etc/cont-init.d/cups.sh
+++ b/cups/rootfs/etc/cont-init.d/cups.sh
@@ -31,37 +31,50 @@ DefaultShared Yes
 JobSheets none,none
 PreserveJobHistory No
 
-# Allow access from local network
+# @LOCAL plus explicit v6 prefixes: Port 631 listens on IPv6 and Apple
+# clients resolve *.local to AAAA first.
 <Location />
   Order allow,deny
   Allow localhost
+  Allow @LOCAL
   Allow 10.0.0.0/8
   Allow 172.16.0.0/12
   Allow 192.168.0.0/16
+  Allow fe80::/10
+  Allow fd00::/8
 </Location>
 
 <Location /admin>
   Order allow,deny
   Allow localhost
+  Allow @LOCAL
   Allow 10.0.0.0/8
   Allow 172.16.0.0/12
   Allow 192.168.0.0/16
+  Allow fe80::/10
+  Allow fd00::/8
 </Location>
 
 <Location /admin/conf>
   Order allow,deny
   Allow localhost
+  Allow @LOCAL
   Allow 10.0.0.0/8
   Allow 172.16.0.0/12
   Allow 192.168.0.0/16
+  Allow fe80::/10
+  Allow fd00::/8
 </Location>
 
 <Location /jobs>
   Order allow,deny
   Allow localhost
+  Allow @LOCAL
   Allow 10.0.0.0/8
   Allow 172.16.0.0/12
   Allow 192.168.0.0/16
+  Allow fe80::/10
+  Allow fd00::/8
 </Location>
 
 # Top-level <Limit> is ignored by cupsd; job ops must live in a Policy.
@@ -77,27 +90,36 @@ PreserveJobHistory No
   <Limit Create-Job Print-Job Print-URI Validate-Job>
     Order allow,deny
     Allow localhost
+    Allow @LOCAL
     Allow 10.0.0.0/8
     Allow 172.16.0.0/12
     Allow 192.168.0.0/16
+    Allow fe80::/10
+    Allow fd00::/8
   </Limit>
 
   <Limit Send-Document Send-URI Hold-Job Release-Job Restart-Job Purge-Jobs Set-Job-Attributes Create-Job-Subscription Renew-Subscription Cancel-Subscription Get-Notifications Reprocess-Job Cancel-Job Cancel-Jobs Cancel-Current-Job Cancel-My-Jobs Suspend-Current-Job Resume-Job Close-Job CUPS-Move-Job CUPS-Get-Document Pause-Printer Resume-Printer Enable-Printer Disable-Printer Pause-Printer-After-Current-Job Hold-New-Jobs Release-Held-New-Jobs CUPS-Accept-Jobs CUPS-Reject-Jobs Promote-Job CUPS-Add-Modify-Printer CUPS-Delete-Printer CUPS-Add-Modify-Class CUPS-Delete-Class CUPS-Set-Default CUPS-Get-Devices>
     AuthType None
     Order allow,deny
     Allow localhost
+    Allow @LOCAL
     Allow 10.0.0.0/8
     Allow 172.16.0.0/12
     Allow 192.168.0.0/16
+    Allow fe80::/10
+    Allow fd00::/8
   </Limit>
 
   <Limit All>
     AuthType None
     Order allow,deny
     Allow localhost
+    Allow @LOCAL
     Allow 10.0.0.0/8
     Allow 172.16.0.0/12
     Allow 192.168.0.0/16
+    Allow fe80::/10
+    Allow fd00::/8
   </Limit>
 </Policy>
 EOL


### PR DESCRIPTION
## Summary
- Advertise shared printers as AirPrint/Bonjour via Avahi in reflector mode (so it can coexist with Home Assistant OS mDNS) and CUPS DNS-SD browsing.
- Fix the web UI Cancel Job button returning Unauthorized: Cancel-Job belongs in a real Policy with AuthType None. The old top-level Limit was ignored, and this image never creates an admin user.
- Allow IPv6 LAN clients (@LOCAL, fe80::/10, fd00::/8). Port 631 listens on IPv6 and macOS prefers AAAA for .local names, which otherwise 403s the main page, CSS, printers, and jobs.
- Bump add-on version to 1.3.2.

Follow-up to #33 (gutenprint-cups). Tested on Home Assistant OS (aarch64 / Raspberry Pi 5) with a Canon PIXMA MG5250.

## Test plan
- [ ] Rebuild/update the add-on on Home Assistant OS
- [ ] Confirm start logs include Avahi started
- [ ] Web UI at :631 loads with CSS over IPv4 and IPv6 (homeassistant.local)
- [ ] Jobs page Cancel Job succeeds without login from a LAN client
- [ ] Shared printer appears as AirPrint on Mac and iPhone (not the printer own LPD name)
- [ ] Existing queues and /share/cups config survive the update
